### PR TITLE
feat: get proposals from block-service #77

### DIFF
--- a/src/components/AccountPermission/AccountPermission.tsx
+++ b/src/components/AccountPermission/AccountPermission.tsx
@@ -11,7 +11,7 @@ const Permission = styled.div`
   margin: 4px 0 4px 16px;
   font-size: 12px;
   max-width: 880px;
-  position:relative;
+  position: relative;
 
   &:not(:last-child)::before {
     content: '';

--- a/src/pages/Proposal/Proposal.connect.tsx
+++ b/src/pages/Proposal/Proposal.connect.tsx
@@ -11,7 +11,7 @@ type Props = {
   };
 };
 
-export type LoadProposalParams = { proposer: string; proposal: string };
+export type LoadProposalsParams = { proposer: string; name: string };
 
 export default connect(
   (state: State, props: Props) => {
@@ -24,21 +24,13 @@ export default connect(
     return { account, proposal, error };
   },
   {
-    loadProposal: (params: LoadProposalParams) => ({
+    loadProposals: (params: LoadProposalsParams) => ({
       type: CALL_API,
-      method: 'stateReader.getProposals',
+      method: 'accounts.getProposals',
       params: {
-        filter: {
-          proposer: params.proposer,
-          proposal_name: params.proposal,
-        },
+        proposer: params.proposer,
+        name: params.name,
       },
-      meta: { ...params },
-    }),
-    loadApprovals: (params: LoadProposalParams) => ({
-      type: CALL_API,
-      method: 'stateReader.getProposalApprovals',
-      params,
       meta: { ...params },
     }),
   }

--- a/src/utils/cyberwayActions.ts
+++ b/src/utils/cyberwayActions.ts
@@ -62,7 +62,7 @@ function msigAction(action: string, actor: string) {
   return actionBase('cyber.msig', action, actor);
 }
 
-export function propose(proposer: string, proposal: string, requested: AuthType[], trx: any) {
+export function maigPropose(proposer: string, proposal: string, requested: AuthType[], trx: any) {
   return {
     ...msigAction('propose', proposer),
     data: {
@@ -74,12 +74,7 @@ export function propose(proposer: string, proposal: string, requested: AuthType[
   };
 }
 
-export function approveProposal(
-  proposer: string,
-  proposal: string,
-  level: AuthType,
-  hash?: string
-) {
+export function msigApprove(proposer: string, proposal: string, level: AuthType, hash?: string) {
   return {
     ...msigAction('approve', level.actor),
     data: {
@@ -91,7 +86,7 @@ export function approveProposal(
   };
 }
 
-export function unapproveProposal(proposer: string, proposal: string, level: AuthType) {
+export function msigUnapprove(proposer: string, proposal: string, level: AuthType) {
   return {
     ...msigAction('unapprove', level.actor),
     data: {
@@ -102,7 +97,7 @@ export function unapproveProposal(proposer: string, proposal: string, level: Aut
   };
 }
 
-export function cancelProposal(proposer: string, proposal: string, canceler = proposer) {
+export function msigCancel(proposer: string, proposal: string, canceler = proposer) {
   return {
     ...msigAction('cancel', canceler),
     data: {
@@ -113,7 +108,7 @@ export function cancelProposal(proposer: string, proposal: string, canceler = pr
   };
 }
 
-export function execProposal(proposer: string, proposal: string, executer = proposer) {
+export function msigExec(proposer: string, proposal: string, executer = proposer) {
   return {
     ...msigAction('exec', executer),
     data: {


### PR DESCRIPTION
+ shows more details about proposal
+ show action buttons only for proposals in state; exec button only for non-expired
+ adds "Unapprove" button for first-voters (builds trx with both `approve` and `unapprove` actions to safely mark approval as unapproved)
+ rename xxxProposal actions to msigXxx
***
resolves #77