### PR TITLE
Support `cyber.msig` v2 #130 #127 #114

### DIFF
--- a/src/pages/Proposals/Proposals.tsx
+++ b/src/pages/Proposals/Proposals.tsx
@@ -107,7 +107,7 @@ export default class Proposals extends PureComponent<Props, State> {
           {updateTime && (
             <>
               ,{' '}
-              <span title="Someone approved, unapproved, executed or cancelled the proposal">
+              <span title="Someone approved, unapproved, scheduled, executed or cancelled the proposal">
                 updated: {formatTime(updateTime)}
               </span>
             </>

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -277,4 +277,5 @@ export type BaseProposalType = {
   finished?: ProposalFinishType;
   updateTime?: string; //Date,
   expires?: string; //Date,
+  scheduled?: string; // Date
 };

--- a/src/utils/cyberwayActions.ts
+++ b/src/utils/cyberwayActions.ts
@@ -98,8 +98,8 @@ export function setProxyLevelAction(account: string, level: number) {
 
 // cyber.msig
 
-function msigAction(action: string, actor: string) {
-  return actionBase('cyber.msig', action, actor);
+function msigAction(action: string, actor: string, permission = 'active') {
+  return actionBase('cyber.msig', action, actor, permission);
 }
 
 export function maigPropose(proposer: string, proposal: string, requested: AuthType[], trx: any) {
@@ -116,7 +116,7 @@ export function maigPropose(proposer: string, proposal: string, requested: AuthT
 
 export function msigApprove(proposer: string, proposal: string, level: AuthType, hash?: string) {
   return {
-    ...msigAction('approve', level.actor),
+    ...msigAction('approve', level.actor, level.permission),
     data: {
       proposer,
       proposal_name: proposal,
@@ -128,7 +128,7 @@ export function msigApprove(proposer: string, proposal: string, level: AuthType,
 
 export function msigUnapprove(proposer: string, proposal: string, level: AuthType) {
   return {
-    ...msigAction('unapprove', level.actor),
+    ...msigAction('unapprove', level.actor, level.permission),
     data: {
       proposer,
       proposal_name: proposal,

--- a/src/utils/cyberwayActions.ts
+++ b/src/utils/cyberwayActions.ts
@@ -158,3 +158,14 @@ export function msigExec(proposer: string, proposal: string, executer = proposer
     },
   };
 }
+
+export function msigSchedule(proposer: string, proposal: string, actor = proposer) {
+  return {
+    ...msigAction('schedule', actor),
+    data: {
+      proposer,
+      proposal_name: proposal,
+      actor,
+    },
+  };
+}


### PR DESCRIPTION
* Adds support of `cyber.msig` v2 (scheduled state) #130
* Use given permission when approve/unapprove proposal; fixes #127
* Add hash when `approve` proposal (prevents proposal replacement) #114
* Fixes status when expired proposal with all approvals was marked "ready" instead of "expired"